### PR TITLE
feat: add new rateFeeds

### DIFF
--- a/config.local.yaml
+++ b/config.local.yaml
@@ -3,6 +3,8 @@ global:
     USDCUSD: '0xa1a8003936862e7a15092a91898d69fa8bce290c'
     USDCEUR: '0x206b25ea01e188ee243131afde526ba6e131a016'
     USDCBRL: '0x25f21a1f97607edf6852339fad709728cffb9a9d'
+    EUROCEUR: '0x26076B9702885d475ac8c3dB3Bd9F250Dc5A318B'
+    XOFEUR: '0x39ffa393566659ffc70d76d238cbe9582042f71f'
 
 chains:
   - id: celo
@@ -15,6 +17,7 @@ chains:
       CELOUSD: '0x765de816845861e75a25fca122bb6898b8b1282a'
       CELOEUR: '0xd8763cba276a3738e6de85b4b3bf5fded6d6ca73'
       CELOBRL: '0xe8537a3d056da446677b9e9d6c5db704eaab4787'
+      CELOXOF: '0x73F93dcc49cB8A239e2032663e9475dd5ef29A08'
   - id: celoAlfajores
     label: alfajores
     httpRpcUrl: https://alfajores-forno.celo-testnet.org
@@ -25,6 +28,7 @@ chains:
       CELOUSD: '0x874069fa1eb16d44d622f2e0ca25eea172369bc1'
       CELOEUR: '0x10c892a6ec43a53e45d0b916b4b7d383b1b78c0f'
       CELOBRL: '0xe4d517785d091d3c54818832db6094bcc2744545'
+      CELOXOF: '0xB0FA15e002516d0301884059c0aaC0F0C72b019D'
   - id: baklava
     label: baklava
     httpRpcUrl: https://baklava-forno.celo-testnet.org
@@ -35,6 +39,7 @@ chains:
       CELOUSD: '0x62492a644a588fd904270bed06ad52b9abfea1ae'
       CELOEUR: '0xf9ece301247ad2ce21894941830a2470f4e774ca'
       CELOBRL: '0x6a0eef2bed4c30dc2cb42fe6c5f01f80f7ef16d1'
+      CELOXOF: '0x64c1D812673E93Bc036AdC3D547d9950696DA5Af'
 
 metrics:
   - source: SortedOracles.numRates(address rateFeed)(uint256)
@@ -45,9 +50,13 @@ metrics:
       - ['CELOUSD']
       - ['CELOEUR']
       - ['CELOBRL']
+      - ['CELOXOF']
       - ['USDCUSD']
       - ['USDCEUR']
       - ['USDCBRL']
+      - ['EUROCEUR']
+      - ['XOFEUR']
+      
   - source: OracleHelper.deviation(address rateFeed)(uint256,uint256)
     schedule: 0/10 * * * * *
     type: gauge
@@ -56,6 +65,9 @@ metrics:
       - ['CELOUSD']
       - ['CELOEUR']
       - ['CELOBRL']
+      - ['CELOXOF']
       - ['USDCUSD']
       - ['USDCEUR']
       - ['USDCBRL']
+      - ['EUROCEUR']
+      - ['XOFEUR']

--- a/config.yaml
+++ b/config.yaml
@@ -3,6 +3,8 @@ global:
     USDCUSD: '0xa1a8003936862e7a15092a91898d69fa8bce290c'
     USDCEUR: '0x206b25ea01e188ee243131afde526ba6e131a016'
     USDCBRL: '0x25f21a1f97607edf6852339fad709728cffb9a9d'
+    EUROCEUR: '0x26076B9702885d475ac8c3dB3Bd9F250Dc5A318B'
+    XOFEUR: '0x39ffa393566659ffc70d76d238cbe9582042f71f'
 
 chains:
   - id: celo
@@ -15,6 +17,7 @@ chains:
       CELOUSD: '0x765de816845861e75a25fca122bb6898b8b1282a'
       CELOEUR: '0xd8763cba276a3738e6de85b4b3bf5fded6d6ca73'
       CELOBRL: '0xe8537a3d056da446677b9e9d6c5db704eaab4787'
+      CELOXOF: '0x73F93dcc49cB8A239e2032663e9475dd5ef29A08'
   - id: celoAlfajores
     label: alfajores
     httpRpcUrl: https://alfajores-forno.celo-testnet.org
@@ -25,6 +28,7 @@ chains:
       CELOUSD: '0x874069fa1eb16d44d622f2e0ca25eea172369bc1'
       CELOEUR: '0x10c892a6ec43a53e45d0b916b4b7d383b1b78c0f'
       CELOBRL: '0xe4d517785d091d3c54818832db6094bcc2744545'
+      CELOXOF: '0xB0FA15e002516d0301884059c0aaC0F0C72b019D'
   - id: baklava
     label: baklava
     httpRpcUrl: https://baklava-forno.celo-testnet.org
@@ -35,6 +39,7 @@ chains:
       CELOUSD: '0x62492a644a588fd904270bed06ad52b9abfea1ae'
       CELOEUR: '0xf9ece301247ad2ce21894941830a2470f4e774ca'
       CELOBRL: '0x6a0eef2bed4c30dc2cb42fe6c5f01f80f7ef16d1'
+      CELOXOF: '0x64c1D812673E93Bc036AdC3D547d9950696DA5Af'
 
 metrics:
   - source: SortedOracles.numRates(address rateFeed)(uint256)
@@ -45,9 +50,13 @@ metrics:
       - ['CELOUSD']
       - ['CELOEUR']
       - ['CELOBRL']
+      - ['CELOXOF']
       - ['USDCUSD']
       - ['USDCEUR']
       - ['USDCBRL']
+      - ['EUROCEUR']
+      - ['XOFEUR']
+      
   - source: OracleHelper.deviation(address rateFeed)(uint256,uint256)
     schedule: 0/10 * * * * *
     type: gauge
@@ -56,6 +65,9 @@ metrics:
       - ['CELOUSD']
       - ['CELOEUR']
       - ['CELOBRL']
+      - ['CELOXOF']
       - ['USDCUSD']
       - ['USDCEUR']
       - ['USDCBRL']
+      - ['EUROCEUR']
+      - ['XOFEUR']


### PR DESCRIPTION
Description: 
- this pr adds the rate feed addresses for the EUROCEUR + XOFEUR + CELOXOF rate feeds 
- the changes are deployed and metrics are collected for the new rates 
- the new rates are included in the alerting but turned off for those rateFeeds that don't report on mainet yet (e.g XOFEUR) 
-  fixes [Ticket 1](https://github.com/mento-protocol/mento-general/issues/249)
- fixes [Ticket2](https://github.com/mento-protocol/mento-general/issues/252)