### PR TITLE
Fix: Outcommented PHPUSD trading mode check (needs CGP to pass first)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,16 @@ pnpm run start:dev
 pnpm run start:prod
 ```
 
+## Checking the Logs & Grafana Dashboard
+
+```bash
+# Tails the logs of the prod aegis app
+pnpm run logs
+
+# Opens the Aegis Grafana Dashboard in your default browser
+pnpm run grafana
+```
+
 ## Test
 
 ```bash

--- a/bin/logs.sh
+++ b/bin/logs.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e          # Fail on any error
+set -o pipefail # Ensure piped commands propagate exit codes properly
+set -u          # Treat unset variables as an error when substituting
+
+# Make sure the mento-prod project is set as the default project
+gcloud config set project mento-prod
+gcloud auth application-default set-quota-project mento-prod
+
+# Fetch the logs from the mento-prod project
+gcloud app logs tail

--- a/config.local.yaml
+++ b/config.local.yaml
@@ -115,4 +115,4 @@ metrics:
       - [EURXOF]
       - [KESUSD]
       - [USDTUSD]
-      - [relayed:PHPUSD]
+      # TODO: Add [relayed:PHPUSD] after PUSO CGP is executed

--- a/config.yaml
+++ b/config.yaml
@@ -115,4 +115,4 @@ metrics:
       - [EURXOF]
       - [KESUSD]
       - [USDTUSD]
-      - [relayed:PHPUSD]
+      # TODO: Add [relayed:PHPUSD] after PUSO CGP is executed

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   "scripts": {
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "grafana": "open https://clabsmento.grafana.net/d/baec6799-0382-4c23-ae44-355300381bbe/aegis-on-chain-data",
+    "logs": "./bin/logs.sh",
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",


### PR DESCRIPTION
Needed to disable the trading mode check for now because PHPUSD is still not whitelisted on SortedOracles until the CGP passes.

Also added some DX convenience tasks to view logs and grafana dashboard, try it out via

- `npm run logs`
- `npm run grafana`