### PR TITLE
feat: enable tradingMode monitoring for PHPUSD

### DIFF
--- a/config.local.yaml
+++ b/config.local.yaml
@@ -115,4 +115,4 @@ metrics:
       - [EURXOF]
       - [KESUSD]
       - [USDTUSD]
-      # TODO: Add [relayed:PHPUSD] after PUSO CGP is executed
+      - [relayed:PHPUSD]

--- a/config.yaml
+++ b/config.yaml
@@ -115,4 +115,4 @@ metrics:
       - [EURXOF]
       - [KESUSD]
       - [USDTUSD]
-      # TODO: Add [relayed:PHPUSD] after PUSO CGP is executed
+      - [relayed:PHPUSD]


### PR DESCRIPTION
### Description

enable TradingMode monitoring for PHPUSD

### Important 
**Should only be merged and deployed after PUSO CGP is executed**


