### PR TITLE
Include variant values in metrics

### DIFF
--- a/src/metrics.service.ts
+++ b/src/metrics.service.ts
@@ -34,6 +34,7 @@ export class MetricsService {
               chain,
               chains.find((c) => c.id == chain).label,
               template.type,
+              configService,
             );
           });
         })

--- a/src/query.service.ts
+++ b/src/query.service.ts
@@ -55,7 +55,6 @@ export class QueryService {
 
     const vars = this.chains[metric.chain].vars;
     const client = this.clients[metric.chain];
-
     const address = this.chains[metric.chain].contracts[metric.source.contract];
     const functionName = metric.source.functionAbi.name;
     const abi = metric.source.functionAbi;

--- a/terraform/grafana-alerts/message-templates.tf
+++ b/terraform/grafana-alerts/message-templates.tf
@@ -45,13 +45,13 @@ resource "grafana_message_template" "low_celo_balance_alert_message" {
 {{ define "discord.message.low_celo_balance_alert_message" }}
 {{ if eq (len .Alerts.Firing) 0 }}No alerts are currently firing.{{ end }}
 {{ range .Alerts.Firing }}
-**🚨 FIRING: Low CELO balance for {{ .Labels.owner }} on {{ .Labels.chain | title }}**
-Current balance: {{ .Values.balanceOf }} CELO
-Please top up the wallet to ensure continued operation of the relayer.
+**🚨 FIRING: Low CELO balance for {{ .Labels.owner }} on {{ .Labels.chain | title }}: {{ .Values.balanceOf }} CELO**
+Please top up the {{ .Labels.owner }} wallet to ensure continued operation of the relayer:
+- Send 500 CELO to the {{ .Labels.owner }} ({{ .Labels.ownerValue }}) on {{ .Labels.chain | title }} from our Deployer wallet
+- You can get the deployer wallet's private key by running `npm run secrets:get` in the `mento-deployment` repo
 {{ end }}
 {{ range .Alerts.Resolved }}
-**✅ RESOLVED: Sufficient CELO balance restored for {{ .Labels.owner }} on {{ .Labels.chain }}**
-Current balance: {{ .Values.balanceOf }} CELO
+**✅ RESOLVED: Sufficient CELO balance restored for {{ .Labels.owner }} on {{ .Labels.chain | title }}: {{ .Values.balanceOf }} CELO**
 {{ end }}
 {{ end }}
 EOT

--- a/terraform/grafana-alerts/message-templates.tf
+++ b/terraform/grafana-alerts/message-templates.tf
@@ -45,13 +45,13 @@ resource "grafana_message_template" "low_celo_balance_alert_message" {
 {{ define "discord.message.low_celo_balance_alert_message" }}
 {{ if eq (len .Alerts.Firing) 0 }}No alerts are currently firing.{{ end }}
 {{ range .Alerts.Firing }}
-**🚨 FIRING: Low CELO balance for {{ .Labels.owner }} on {{ .Labels.chain | title }}: {{ .Values.balanceOf }} CELO**
-Please top up the {{ .Labels.owner }} wallet to ensure continued operation of the relayer:
-- Send 500 CELO to the {{ .Labels.owner }} ({{ .Labels.ownerValue }}) on {{ .Labels.chain | title }} from our Deployer wallet
-- You can get the deployer wallet's private key by running `npm run secrets:get` in the `mento-deployment` repo
+**🚨 FIRING: Low CELO balance for {{ .Labels.owner }} on {{ .Labels.chain | title }} — {{ .Values.balanceOf }} CELO left**
+- Please top up the {{ .Labels.owner }} wallet to ensure continued operation of the relayer
+- Send 500 CELO to the {{ .Labels.owner }} ([{{ .Labels.ownerValue }}](https://{{ if eq .Labels.chain "alfajores" }}alfajores.{{ end }}celoscan.io/address/{{ .Labels.ownerValue }})) on {{ .Labels.chain | title }} from our Deployer wallet
+- You can get the deployer wallet's private key by running `npm run secrets:get` in the [mento-deployment](https://github.com/mento-protocol/mento-deployment/blob/main/bin/get-secrets.sh) repo
 {{ end }}
 {{ range .Alerts.Resolved }}
-**✅ RESOLVED: Sufficient CELO balance restored for {{ .Labels.owner }} on {{ .Labels.chain | title }}: {{ .Values.balanceOf }} CELO**
+**✅ RESOLVED: Sufficient CELO balance restored for [{{ .Labels.owner }}](https://{{ if eq .Labels.chain "alfajores" }}alfajores.{{ end }}celoscan.io/address/{{ .Labels.ownerValue }}) on {{ .Labels.chain | title }} — {{ .Values.balanceOf }} CELO**
 {{ end }}
 {{ end }}
 EOT


### PR DESCRIPTION
### Description

So far, we have only included the variant label in the Prometheus metrics, not the actual variant value. I wanted to add the address of the relayer signer wallet to the alert messages so it will become clear just by reading the message where an on-call engineer would have to send Celo without having to context-switch and figure out where to get the address of the signer from.

The current legacy oracle client alerts do include the oracle address:

<img width="1245" alt="Screenshot 2024-09-23 at 12 40 25" src="https://github.com/user-attachments/assets/783b1386-3964-47aa-b823-a0f02827ede7">

But the standard aegis metrics do not:

<img width="1131" alt="Screenshot 2024-09-23 at 12 41 03" src="https://github.com/user-attachments/assets/4e5b7a70-86cc-4934-a2a6-6760b182062b">


So, I augmented the metric service to now include not only the label name, which would be the variant like `USDCBRL` or `RelayerSignerPHPUSD`, but also the actual variant value, like `0x25f21a1f97607edf6852339fad709728cffb9a9d` for USDCBRL or `0xb2cE6fa691b58Ff4fadBd610a8e09427d2918025` for RelayerSignerPHPUSD.

I then updated the Grafana alert message template to make use of the newly included value.

Not having worked with `prom-client` before, I'm not sure if this is the correct or best way to do it but it seems to work at least locally with `npm run dev`.

Happy over feedback.

### How to test
- [ ] Check out the `main` branch locally
- [ ] Run `npm run dev`
- [ ] See that i.e. the `numRates` log only includes the variant name `CELOEUR` but not its value, log should look like this:
   - `[Nest] 97123  - 09/23/2024, 12:35:48 PM   DEBUG [MetricsService] numRates{"rateFeed":"CELOEUR","chain":"alfajores"} = 3`
- [ ] Now check out this branch locally
- [ ] Re-run `npm run dev`
- [ ] See that the logs now include also the value of the variant (`rateFeedValue`):
   - `[Nest] 98479  - 09/23/2024, 12:36:21 PM   DEBUG [MetricsService] numRates{"rateFeed":"CELOEUR","rateFeedValue":"0x10c892a6ec43a53e45d0b916b4b7d383b1b78c0f","chain":"alfajores"} = 3`