### PR TITLE
Increase reserve alert condition violation period from 1m to 60m

### DIFF
--- a/terraform/grafana-alerts/alert-rules-reserve-balances.tf
+++ b/terraform/grafana-alerts/alert-rules-reserve-balances.tf
@@ -16,7 +16,11 @@ resource "grafana_rule_group" "reserve_balances" {
     content {
       name      = "Low ${rule.key} Reserve Balance Alert"
       condition = "lowerThan${rule.value.threshold / 1000000}m${rule.key}"
-      for       = "1m"
+
+      # Threshold must be breached for at least 1 hour, using the default 1m could get very noisy
+      # Because due to trades it could temporarily dip below the threshold and then back above it
+      # many times causing a lot of alerts.
+      for = "60m"
       annotations = {
         summary        = "Low ${rule.key} Reserve Balance: {{ humanize (index $values \"balance\").Value }} ${rule.key}"
         threshold      = "{{ humanize (${rule.value.threshold}) }}"


### PR DESCRIPTION
1m led to too much noise when the balance is close to the threshold. due to trades in both directions the balance could go slightly above or below the threshold multiple times causing a lot of alerts.

<img width="697" alt="image" src="https://github.com/user-attachments/assets/c30de235-37c6-4e68-858b-f1aa8db5d28d">

