### PR TITLE
Show correct CELO balances in Discord alert messages

### DIFF
--- a/terraform/grafana-alerts/alert-rules-oracle-relayers.tf
+++ b/terraform/grafana-alerts/alert-rules-oracle-relayers.tf
@@ -84,7 +84,8 @@ resource "grafana_rule_group" "oracle_relayers" {
       condition = "lowerThan20CELO"
       for       = "1m" // Alert if balance is low for at least 1 minutes
       annotations = {
-        summary = "Low CELO balance for {{ $labels.owner }} on {{ $labels.chain | title }}. Current balance: {{ $values.CELOToken_balanceOf }} CELO"
+        summary        = "Low CELO balance for {{ $labels.owner }} on {{ $labels.chain | title }}: {{ humanize (index $values \"balance\").Value }} CELO"
+        currentBalance = "{{ humanize (index $values \"balance\").Value }}"
       }
       labels = {
         service  = "oracle-relayers"
@@ -107,7 +108,7 @@ resource "grafana_rule_group" "oracle_relayers" {
         })
       }
       data {
-        ref_id         = "balanceOf"
+        ref_id         = "balance"
         datasource_uid = "__expr__"
         relative_time_range {
           from = 0
@@ -117,7 +118,7 @@ resource "grafana_rule_group" "oracle_relayers" {
           expression = "balanceOfRaw",
           type       = "reduce",
           reducer    = "last",
-          refId      = "balanceOf"
+          refId      = "balance"
         })
       }
       data {
@@ -129,7 +130,7 @@ resource "grafana_rule_group" "oracle_relayers" {
         }
         model = jsonencode({
           type       = "threshold",
-          expression = "balanceOf",
+          expression = "balance",
           refId      = "lowerThan20CELO"
           conditions = [
             {

--- a/terraform/grafana-alerts/message-templates-oracles.tf
+++ b/terraform/grafana-alerts/message-templates-oracles.tf
@@ -45,13 +45,14 @@ resource "grafana_message_template" "oracle_relayer_low_celo_balance_alert_messa
 {{ define "discord.oracle_relayer_low_celo_balance_alert_message" }}
 {{ if eq (len .Alerts.Firing) 0 }}No alerts are currently firing.{{ end }}
 {{ range .Alerts.Firing }}
-**🚨 FIRING: Low CELO balance for {{ .Labels.owner }} on {{ .Labels.chain | title }} — {{ .Values.CELOToken_balanceOf }} CELO left**
+**🚨 FIRING: Low CELO balance for {{ .Labels.owner }} on {{ .Labels.chain | title }} — {{ .Annotations.currentBalance }} CELO left**
 - Please top up the {{ .Labels.owner }} wallet to ensure continued operation of the relayer
 - Send 500 CELO to the {{ .Labels.owner }} ([{{ .Labels.ownerValue }}](https://{{ if eq .Labels.chain "alfajores" }}alfajores.{{ end }}celoscan.io/address/{{ .Labels.ownerValue }})) on {{ .Labels.chain | title }} from our Deployer wallet
 - You can get the deployer wallet's private key by running `npm run secrets:get` in the [mento-deployment](https://github.com/mento-protocol/mento-deployment/blob/main/bin/get-secrets.sh) repo
 {{ end }}
 {{ range .Alerts.Resolved }}
-**✅ RESOLVED: Sufficient CELO balance restored for [{{ .Labels.owner }}](https://{{ if eq .Labels.chain "alfajores" }}alfajores.{{ end }}celoscan.io/address/{{ .Labels.ownerValue }}) on {{ .Labels.chain | title }} — {{ .Values.CELOToken_balanceOf }} CELO**
+**✅ RESOLVED: Sufficient CELO balance restored for [{{ .Labels.owner }}](https://{{ if eq .Labels.chain "alfajores" }}alfajores.{{ end }}celoscan.io/address/{{ .Labels.ownerValue }}) on {{ .Labels.chain | title }} — {{ .Annotations.currentBalance }} CELO**
+
 {{ end }}
 {{ end }}
 EOT


### PR DESCRIPTION
### Description
Small fix to show correct CELO balance values of Oracle Relayers in Discord Alerts.

We previously used the wrong ref id, and undefined ref IDs always showed up as "0"

### How to review
- [ ] Verify that the _"Low CELO Balance Alert [Alfajores]"_ in our [Grafana Alerts](https://clabsmento.grafana.net/alerting/list) now have a `currentBalance` annotation displaying the correct current CELO balance values for the respective relayers
- [ ] Check the code

<img width="899" alt="image" src="https://github.com/user-attachments/assets/937c1fb4-26ac-4c3f-a49f-8f8618a82ce5">
