### PR TITLE
chore: add COPUSD trading mode metric

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -117,7 +117,9 @@ metrics:
       - [USDCEUR]
       - [USDCUSD]
       - [USDTUSD]
+      # NOTE: We filtered out derived CELO rate feeds like 'relayed:CELOPHP' here because we typically don't add breakers for them
       - [relayed:PHPUSD]
+      - [relayed:COPUSD]
 
   # Checks for rate feed freshness
   - source: SortedOracles.isOldestReportExpired(address rateFeed)(bool,address)


### PR DESCRIPTION
### Description

Couldn't add it as part of https://github.com/mento-protocol/aegis/pull/25 as the $cCOP launch proposal had not been executed then

### Other changes

N/A

### Tested

Checked that it works locally
```
BreakerBox_getRateFeedTradingMode{rateFeed="relayed:COPUSD",rateFeedValue="0x0196D1F4FdA21fA442e53EaF18Bf31282F6139F1",chain="celo"} 0
BreakerBox_getRateFeedTradingMode{rateFeed="relayed:COPUSD",rateFeedValue="0x0196D1F4FdA21fA442e53EaF18Bf31282F6139F1",chain="alfajores"} 0
```

Update: deployed to PROD and it looks good on grafana
<img width="585" alt="Screenshot 2024-11-06 at 14 30 05" src="https://github.com/user-attachments/assets/16a700cf-d160-49bb-92dc-ce08547fbd0d">

### Issue

Fixes https://github.com/mento-protocol/mento-general/issues/578