### PR TITLE
Increase pending period for trading limit alerts to 5m

### DIFF
--- a/terraform/grafana-alerts/alert-rules-trading-modes.tf
+++ b/terraform/grafana-alerts/alert-rules-trading-modes.tf
@@ -9,6 +9,7 @@ resource "grafana_rule_group" "trading_modes" {
     content {
       name      = "Trading Mode Alert [${title(rule.value)}]"
       condition = "isTradingHalted"
+      for       = "5m"
       annotations = {
         summary = "Trading is halted for the {{ $labels.rateFeed }} rate feed on {{ $labels.chain | title }}. Check if a breaker tripped."
       }


### PR DESCRIPTION
We had no pending period for Trading Mode alerts which led to a bit of noise in the #alerts-catch-all channel

This PR adds a pending period of 5mins which should reduce these false positive alerts by a bit

<img width="930" alt="image" src="https://github.com/user-attachments/assets/4d73be12-cd6b-4945-9652-f27bb3cb6d71">
