### PR TITLE
Increase alert evaluation interval from 1m to 2m

### DIFF
--- a/terraform/grafana-alerts/alert-rules-oracle-relayers.tf
+++ b/terraform/grafana-alerts/alert-rules-oracle-relayers.tf
@@ -1,7 +1,7 @@
 resource "grafana_rule_group" "oracle_relayers" {
   name             = "Oracle Relayer Alerts"
   folder_uid       = var.oracle_relayers_folder.uid
-  interval_seconds = 60
+  interval_seconds = 120
 
   dynamic "rule" {
     for_each = local.chains

--- a/terraform/grafana-alerts/alert-rules-reserve-balances.tf
+++ b/terraform/grafana-alerts/alert-rules-reserve-balances.tf
@@ -3,7 +3,7 @@
 resource "grafana_rule_group" "reserve_balances" {
   name             = "Reserve Balance Alerts"
   folder_uid       = var.reserve_folder.uid
-  interval_seconds = 60
+  interval_seconds = 120
 
   dynamic "rule" {
     for_each = {

--- a/terraform/grafana-alerts/alert-rules-trading-modes.tf
+++ b/terraform/grafana-alerts/alert-rules-trading-modes.tf
@@ -1,7 +1,7 @@
 resource "grafana_rule_group" "trading_modes" {
   name             = "Trading Mode Alerts"
   folder_uid       = var.trading_modes_folder.uid
-  interval_seconds = 60
+  interval_seconds = 120
 
   dynamic "rule" {
     for_each = local.chains


### PR DESCRIPTION
We were often getting these "No Data" alerts because it seems like aegis is not always reliably reporting values every minute, it sometimes skips a minute, see logs:

<img width="679" alt="Screenshot 2024-11-07 at 15 48 40" src="https://github.com/user-attachments/assets/965149dd-6ae4-4920-87ae-db555cfc5455">

This PR increases the alert rule evaluation frequency from 1 to 2 minutes which should hopefully reduce the noise a little bit from these "no data" alerts