### PR TITLE
feat(alerts): increase query interval to reduce alert noise (last try…)

### DIFF
--- a/terraform/grafana-alerts/alert-rules-reserve-balances.tf
+++ b/terraform/grafana-alerts/alert-rules-reserve-balances.tf
@@ -17,10 +17,13 @@ resource "grafana_rule_group" "reserve_balances" {
       name      = "Low ${rule.key} Reserve Balance Alert"
       condition = "lowerThan${rule.value.threshold / 1000000}m${rule.key}"
 
-      # Threshold must be breached for at least 1 hour, using the default 1m could get very noisy
-      # Because due to trades it could temporarily dip below the threshold and then back above it
-      # many times causing a lot of alerts.
-      for = "60m"
+      # Threshold must be breached for at least 1 hour. Using the default 1m could get very noisy.
+      # Because due to trades in both directions, it could temporarily dip below the threshold and
+      # then back above it many times, causing a lot of alerts.
+      for            = "60m"
+      exec_err_state = "Error"
+      no_data_state  = "NoData"
+
       annotations = {
         summary        = "Low ${rule.key} Reserve Balance: {{ humanize (index $values \"balance\").Value }} ${rule.key}"
         threshold      = "{{ humanize (${rule.value.threshold}) }}"
@@ -31,9 +34,6 @@ resource "grafana_rule_group" "reserve_balances" {
         severity = "warning"
         token    = rule.value.token
       }
-      exec_err_state = "Error"
-      is_paused      = false
-      no_data_state  = "NoData"
 
       data {
         ref_id         = "a"

--- a/terraform/grafana-alerts/alert-rules-trading-modes.tf
+++ b/terraform/grafana-alerts/alert-rules-trading-modes.tf
@@ -7,19 +7,20 @@ resource "grafana_rule_group" "trading_modes" {
     for_each = local.chains
 
     content {
-      name      = "Trading Mode Alert [${title(rule.value)}]"
-      condition = "isTradingHalted"
-      for       = "5m"
+      name           = "Trading Mode Alert [${title(rule.value)}]"
+      condition      = "isTradingHalted"
+      for            = "5m"
+      exec_err_state = "Error"
+      no_data_state  = "NoData"
+
       annotations = {
         summary = "Trading is halted for the {{ $labels.rateFeed }} rate feed on {{ $labels.chain | title }}. Check if a breaker tripped."
       }
+
       labels = {
         service  = "exchanges"
         severity = "warning"
       }
-      exec_err_state = "Error"
-      is_paused      = false
-      no_data_state  = "NoData"
 
       data {
         ref_id         = "tradingMode"
@@ -31,11 +32,9 @@ resource "grafana_rule_group" "trading_modes" {
         }
 
         model = jsonencode({
-          refId         = "tradingMode"
-          expr          = "BreakerBox_getRateFeedTradingMode{chain=\"${rule.value}\"}"
-          instant       = true
-          intervalMs    = 1000
-          maxDataPoints = 43200
+          refId   = "tradingMode"
+          expr    = "BreakerBox_getRateFeedTradingMode{chain=\"${rule.value}\"}"
+          instant = true
         })
       }
       data {
@@ -69,7 +68,6 @@ resource "grafana_rule_group" "trading_modes" {
             uid  = "__expr__"
           }
           expression = "tradingMode"
-          intervalMs = 1000
           type       = "threshold"
         })
       }


### PR DESCRIPTION
My last idea is that the `intervalMs=1000` was too low causing queries to run every second which may have been too frequent to tolerate these 1-2min periods of "NoData" we're seeing from time to time on grafana