### PR TITLE
chore: fixed duplicate oracle relayer alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ pnpm run tf:deploy
    - Add the new rate feeds as variants to the `SortedOracles.isOldestReportExpired()` metric
    - Add the new rate feeds as variants to the `BreakerBox.getRateFeedTradingMode()` metric
    - Add the new relayer signer as variants to the `CELOToken.balanceOf()` metric
+1. [optional] If it's an FX rate feed with disabled trading on weekends because we don't get new price data on weekends:
+   - Add the rate feed name to the `weekend_disabled_feeds` array in [grafana-alerts/locals.tf](./terraform/grafana-alerts/locals.tf#L7)
 1. Test the new config locally by running `pnpm start` and checking for any errors in the logs
 1. After code review, deploy the new config via `pnpm run deploy`
 1. After successful deployment, check the logs for any errors via `pnpm run logs`

--- a/terraform/grafana-alerts/locals.tf
+++ b/terraform/grafana-alerts/locals.tf
@@ -2,6 +2,20 @@
 # See https://www.terraform.io/docs/language/values/locals.html
 locals {
   chains = ["celo", "alfajores"]
+
+  # Weekend-disabled feeds that don't receive updates during market closing hours
+  weekend_disabled_feeds = [
+    "relayed:PHPUSD",
+    "relayed:COPUSD",
+    "relayed:GHSUSD",
+    "relayed:CELOPHP",
+    "relayed:CELOCOP",
+    "relayed:CELOGHS"
+  ]
+
+  # Create a regex pattern for the weekend-disabled feeds
+  weekend_disabled_feeds_pattern = join("|", local.weekend_disabled_feeds)
+
   alert_types = {
     oracle_stale_price = {
       names = [

--- a/terraform/grafana-alerts/notification-policies.tf
+++ b/terraform/grafana-alerts/notification-policies.tf
@@ -38,7 +38,45 @@ resource "grafana_notification_policy" "all" {
         value = "alfajores"
       }
 
+      # Exclude the weekend-disabled feeds
+      matcher {
+        label = "rateFeed"
+        match = "!~"
+        value = local.weekend_disabled_feeds_pattern
+      }
+
       continue = true
+    }
+
+    # Mute notifications on weekends for FX feeds that don't receive new data on weekends [Alfajores]
+    policy {
+      # Apply the mute timing to the policy
+      mute_timings = [grafana_mute_timing.weekend_mute.name]
+
+      # Use the same contact point as the Alfajores Oracle Relayer policy
+      contact_point = grafana_contact_point.discord_channel_oracle_relayers_staging.name
+
+      # Only apply this policy to the weekend-disabled feeds
+      matcher {
+        label = "service"
+        match = "="
+        value = "oracle-relayers"
+      }
+
+      matcher {
+        label = "chain"
+        match = "="
+        value = "alfajores"
+      }
+
+      matcher {
+        label = "rateFeed"
+        match = "=~"
+        value = local.weekend_disabled_feeds_pattern
+      }
+
+      # Set continue to false to prevent further processing of these specific alerts
+      continue = false
     }
 
     # Oracle Relayer Alerts [Celo Mainnet]
@@ -57,6 +95,13 @@ resource "grafana_notification_policy" "all" {
         value = "celo"
       }
 
+      # Exclude the weekend-disabled feeds
+      matcher {
+        label = "rateFeed"
+        match = "!~"
+        value = local.weekend_disabled_feeds_pattern
+      }
+
       continue = true
     }
 
@@ -65,15 +110,30 @@ resource "grafana_notification_policy" "all" {
       # Apply the mute timing to the policy
       mute_timings = [grafana_mute_timing.weekend_mute.name]
 
+      # Use the same contact point as the main Oracle Relayer policy
+      contact_point = grafana_contact_point.discord_channel_oracle_relayers_prod.name
+
       # Only apply this policy to the weekend-disabled feeds
+      matcher {
+        label = "service"
+        match = "="
+        value = "oracle-relayers"
+      }
+
+      matcher {
+        label = "chain"
+        match = "="
+        value = "celo"
+      }
+
       matcher {
         label = "rateFeed"
         match = "=~"
-        value = "relayed:PHPUSD|relayed:COPUSD|relayed:GHSUSD|relayed:CELOPHP|relayed:CELOCOP|relayed:CELOGHS"
+        value = local.weekend_disabled_feeds_pattern
       }
 
-      # Continue processing other policies
-      continue = true
+      # Set continue to false to prevent further processing of these specific alerts
+      continue = false
     }
 
     # Reserve Alerts


### PR DESCRIPTION
### Description

My last notification policy update unintendedly led to duplicate alerts for the Oracle relayers. The correct one was posted in #stg-oracle-relayers, but there was also an additional one going to #alerts-catch-all every time.

### Other changes

- [x] Extracted weekend-disabled feeds into local variables and avoid hardcoding in multiple places

### Tested

Made sure that only 1 alert is firing now. (Compare the 09:13 alert in [#stg-oracle-relayers](https://discord.com/channels/966739027782955068/1280908625711468586/1348931714742878219) that also triggered in [#alerts-catch-all](https://discord.com/channels/966739027782955068/1283736128939102260/1348931714872774717)
 with the alert after I deployed the fix at 10:26 which only fired in [#stg-oracle-relayers](https://discord.com/channels/966739027782955068/1280908625711468586/1348950220104269855))