### PR TITLE
fix(grafana-agent): use Debian user-creation commands in Dockerfile

### DIFF
--- a/grafana-agent/Dockerfile
+++ b/grafana-agent/Dockerfile
@@ -3,9 +3,11 @@ FROM grafana/agent:v0.35.0
 # Add healthcheck
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD wget --no-verbose --tries=1 --spider http://localhost:12345/-/healthy || exit 1
 
-# Create a non-root user for security
-RUN addgroup -g 1000 agent && \
-    adduser -D -u 1000 -G agent agent
+# Create a non-root user for security.
+# `grafana/agent:v0.35.0` is Debian-based, so BusyBox-style `addgroup`/
+# `adduser -D` aren't available — use groupadd/useradd instead.
+RUN groupadd -g 1000 agent && \
+    useradd -u 1000 -g agent -M -s /usr/sbin/nologin agent
 
 COPY agent.yaml /etc/agent/agent.yaml
 


### PR DESCRIPTION
## Summary

`gcloud builds submit` on the `grafana-agent` directory fails with:

```
Step 3/5 : RUN addgroup -g 1000 agent && adduser -D -u 1000 -G agent agent
/bin/sh: 1: addgroup: not found
The command ... returned a non-zero code: 127
```

Root cause: #47 ("Add Trunk + Update Dependencies") added a hardening step that creates a non-root `agent` user using **Alpine/BusyBox** syntax (`addgroup -g`, `adduser -D`), but `grafana/agent:v0.35.0` is **Debian-based**. No redeploy happened between #47 merging and this week, so the break only surfaced when the #48 scrape-config change triggered the first rebuild.

## Fix

Swap to Debian-native `groupadd`/`useradd`, same uid/gid (1000), no home dir, `/usr/sbin/nologin` shell. Behaviorally equivalent to the original intent.

```dockerfile
RUN groupadd -g 1000 agent && \
    useradd -u 1000 -g agent -M -s /usr/sbin/nologin agent
```

## Test plan

- [x] `trunk check grafana-agent/Dockerfile` — clean
- [ ] After merge: `cd grafana-agent && gcloud builds submit` completes, App Engine rolls the new revision with the v3 scrape target active, `mento_pool_*` metrics appear in Grafana Cloud

## Followup candidate (not in this PR)

`grafana/agent` is deprecated in favor of Grafana Alloy — v0.35.0 is 2023-vintage and receives no updates. Worth a separate migration PR when someone has the cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)