### PR TITLE
fix(grafana-agent): bump Dockerfile uid/gid to 10001 to avoid base-image collision

### DIFF
--- a/grafana-agent/Dockerfile
+++ b/grafana-agent/Dockerfile
@@ -4,10 +4,11 @@ FROM grafana/agent:v0.35.0
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD wget --no-verbose --tries=1 --spider http://localhost:12345/-/healthy || exit 1
 
 # Create a non-root user for security.
-# `grafana/agent:v0.35.0` is Debian-based, so BusyBox-style `addgroup`/
-# `adduser -D` aren't available — use groupadd/useradd instead.
-RUN groupadd -g 1000 agent && \
-    useradd -u 1000 -g agent -M -s /usr/sbin/nologin agent
+# `grafana/agent:v0.35.0` is Debian-based (BusyBox `addgroup`/`adduser -D`
+# aren't available) AND already uses GID/UID 1000 for its built-in `grafana`
+# account, so we pick 10001 to avoid the collision.
+RUN groupadd -g 10001 agent && \
+    useradd -u 10001 -g agent -M -s /usr/sbin/nologin agent
 
 COPY agent.yaml /etc/agent/agent.yaml
 


### PR DESCRIPTION
## Summary

After #51 fixed the Alpine→Debian command mismatch, `gcloud builds submit` failed on the next step with:

```
groupadd: GID '1000' already exists
returned a non-zero code: 4
```

`grafana/agent:v0.35.0` already has a built-in `grafana` account at UID/GID 1000, so `groupadd -g 1000` collides.

## Fix

Move the new `agent` user to 10001/10001 — conventionally reserved for application-defined service accounts, well clear of base-image defaults.

## Test plan

- [x] `trunk check grafana-agent/Dockerfile` — clean
- [ ] After merge: `cd grafana-agent && gcloud builds submit` completes through all 5 Dockerfile steps and App Engine rolls the new revision

🤖 Generated with [Claude Code](https://claude.com/claude-code)