### PR TITLE
fix(grafana-agent): drop deprecated server block from agent.yaml.tmpl

### DIFF
--- a/grafana-agent/agent.yaml.tmpl
+++ b/grafana-agent/agent.yaml.tmpl
@@ -1,6 +1,8 @@
-server:
-  log_level: info
-  http_listen_port: 12345
+# `server` block used to carry `log_level` + `http_listen_port` here; those
+# fields were removed from the static-mode schema in v0.26.0. The image's
+# default CMD already passes `-server.http.address=0.0.0.0:12345` + the
+# log level flags, so the block is unnecessary — and an empty `server:`
+# would fail validation on startup.
 
 metrics:
   wal_directory: /etc/agent/data


### PR DESCRIPTION
## Summary

After the Dockerfile fixes in #51 + #52 got the container building + pushing, App Engine's deploy-time health check failed with:

```
error loading config file /etc/agent/agent.yaml: yaml: unmarshal errors:
line 3: field http_listen_port not found in type server.config
```

Per the grafana-agent v0.35.0 CHANGELOG:

> Most fields in the `server` block of the configuration file are now deprecated in favor of command line flags. These fields will be removed in the v0.26.0 release.

We're on v0.35.0 (the image tag), so `server.log_level` and `server.http_listen_port` have been gone from the static-mode schema for ~2 years. The image's default CMD already sets:

```
-server.http.address=0.0.0.0:12345
```

so the block is unnecessary. An empty `server:` also fails validation (per the same CHANGELOG: "An empty `server:` is considered a misconfiguration, and thus will error out."), so remove the whole block.

## Why this lay dormant

No one has run `gcloud builds submit` against this Dockerfile since the repo was initially scaffolded with `FROM grafana/agent:v0.35.0` (commit `216fb05`, "forge init"). The yaml issue rode alongside:
- Alpine/Debian command mismatch (fixed in #51)
- GID 1000 base-image collision (fixed in #52)
- This schema removal (fixed here)

Three different latent bugs surfaced in order as earlier ones got fixed.

## Test plan

- [x] `trunk check grafana-agent/agent.yaml.tmpl` — clean
- [ ] After merge: `cd grafana-agent && gcloud builds submit` → App Engine rolls the new grafana-agent revision, container passes health check, `mento_pool_*` metrics appear in Grafana Cloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-template change that only drops fields removed from the Grafana Agent schema; main risk is misconfiguration if the container CMD/flags don’t set the expected listen address/log level.
> 
> **Overview**
> Removes the `server` block (previously setting `log_level` and `http_listen_port`) from `grafana-agent/agent.yaml.tmpl` because those fields are no longer accepted by the Grafana Agent static-mode schema.
> 
> Adds inline comments explaining that the container’s default command-line flags already provide the server address/log level and that an empty `server:` would fail validation, preventing deploy-time startup errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2b0be85444d55447e05da4c450fcbbecc5a07e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->