### PR TITLE
fix(grafana-agent): grant agent user write access to WAL directory

### DIFF
--- a/grafana-agent/Dockerfile
+++ b/grafana-agent/Dockerfile
@@ -10,7 +10,12 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD wget 
 RUN groupadd -g 10001 agent && \
     useradd -u 10001 -g agent -M -s /usr/sbin/nologin agent
 
-COPY agent.yaml /etc/agent/agent.yaml
+# Prometheus WAL directory (configured in agent.yaml as `wal_directory`).
+# /etc is owned by root, so the non-root `agent` user can't `mkdir` at
+# runtime — pre-create and chown here.
+RUN mkdir -p /etc/agent/data && chown -R agent:agent /etc/agent
+
+COPY --chown=agent:agent agent.yaml /etc/agent/agent.yaml
 
 # Switch to non-root user
 USER agent


### PR DESCRIPTION
## Summary

Deploy got through the build + push steps, App Engine spun up the new version, but the container restart-loops with:

```
error creating WAL: create dir: mkdir /etc/agent/data: permission denied
```

The non-root `agent` user (uid 10001, introduced in #52) can't create subdirs of `/etc/agent/` because /etc is root-owned. The old version ran as root so this was never an issue.

## Fix

Pre-create the WAL directory and chown to `agent` during image build. Also `--chown=agent:agent` on the `COPY agent.yaml` for consistency.

```dockerfile
RUN mkdir -p /etc/agent/data && chown -R agent:agent /etc/agent
COPY --chown=agent:agent agent.yaml /etc/agent/agent.yaml
```

## Context — fourth latent grafana-agent bug this session

All four were introduced by #47 ("Add Trunk + Update Dependencies") which added a `HEALTHCHECK` + non-root user but was never actually deployed. Surfaced in order as each got fixed:

| PR | Break | Fix |
|---|---|---|
| #51 | Alpine `addgroup`/`adduser -D` on a Debian base | Debian `groupadd`/`useradd` |
| #52 | `GID 1000` collides with `grafana/agent:v0.35.0`'s built-in user | Move to 10001 |
| #53 | `server.http_listen_port` removed from static-mode schema in v0.26.0 | Drop the `server:` block |
| **This** | `/etc/agent/` is root-owned, non-root user can't create WAL dir | chown at build time |

## Test plan

- [x] `trunk check grafana-agent/Dockerfile` — clean
- [ ] After merge: `cd grafana-agent && gcloud builds submit` → container boots, no permission errors in logs, /-/healthy returns 200, `mento_pool_*` metrics land in Grafana Cloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: Docker image build-time permission changes to prevent startup failures; main risk is unintended ownership/permissions under `/etc/agent` affecting runtime behavior.
> 
> **Overview**
> Fixes grafana-agent container restart loops by **pre-creating the Prometheus WAL directory** at `/etc/agent/data` during image build and `chown`ing `/etc/agent` to the non-root `agent` user.
> 
> Also updates the config `COPY` to use `--chown=agent:agent` so `agent.yaml` ownership matches the runtime user.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 006ad1daf1a376b1ac988dfa15c9ed47322526d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->